### PR TITLE
README: fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Accepts the following props:
 - **lineWidth:** _\(default 1px\)_ The width of the Path as a [css length](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
 - **lineColor:** _\(default black\)_ The color of the Path as a [css color](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
 - **lineStyle:** _\(default solid\)_ The line style as a [css line-style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#values)
-- **lineBorderRadius:** _\(default 5px\)_ The color of the Path as a [css border-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
+- **lineBorderRadius:** _\(default 5px\)_ The border radius of the Path as a [css border-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
 - **nodePadding:** _\(default 5px\)_ The left and right padding of every `<TreeNode>` as a [css length](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
 
 ### `TreeNode` - A node in the tree


### PR DESCRIPTION
I fixed a typo in the README file regarding the `lineBorderRadius` prop of the `Tree` component.